### PR TITLE
Fix reauth UX: friendly entry title and dialog description

### DIFF
--- a/custom_components/postnl/config_flow.py
+++ b/custom_components/postnl/config_flow.py
@@ -39,8 +39,10 @@ class OAuth2FlowHandler(
     async def async_oauth_create_entry(self, data: dict) -> dict:
         """Create an oauth config entry or update existing entry for reauth."""
         if self.reauth_entry:
-            self.hass.config_entries.async_update_entry(self.reauth_entry, data=data)
+            self.hass.config_entries.async_update_entry(
+                self.reauth_entry, title="PostNL", data=data
+            )
             await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
             return self.async_abort(reason="reauth_successful")
 
-        return await super().async_oauth_create_entry(data)
+        return self.async_create_entry(title="PostNL", data=data)

--- a/custom_components/postnl/strings.json
+++ b/custom_components/postnl/strings.json
@@ -1,5 +1,16 @@
 {
     "application_credentials": {
         "description": "IMPORTANT: installing this integration is only possible if you use the Chrome extension (see Github repo). You can just put in random data in the Client ID and Client secret fields, the integration ignores the information."
+    },
+    "config_flow": {
+        "step": {
+            "reauth_confirm": {
+                "title": "Opnieuw inloggen bij PostNL",
+                "description": "Je PostNL-sessie is verlopen. Klik op Verzenden om opnieuw in te loggen."
+            }
+        },
+        "abort": {
+            "reauth_successful": "Opnieuw inloggen geslaagd"
+        }
     }
 }


### PR DESCRIPTION
- Set config entry title to "PostNL" instead of the raw client_id, both on first install and when re-authenticating
- Add config_flow strings for reauth_confirm step so the dialog shows a title and explanation instead of an empty form